### PR TITLE
Add info for alternate database queries, updated some wording

### DIFF
--- a/Extensions_to_Yealink_AddressBook/ylab.php
+++ b/Extensions_to_Yealink_AddressBook/ylab.php
@@ -3,8 +3,8 @@
 ylab.php (short for yealink address book) was taken directly from yl.php and modified.
 https://github.com/sorvani/freepbx-helper-scripts/blob/master/yl.php
 
-The purpose of this file is to read all the extensions in the system and then output them in a
-Yealink Remote Address Book formatted XML syntax.
+The purpose of this file is to read all the extensions in the system and then
+output them in a Yealink Remote Address Book formatted XML syntax.
 
 Updated December 24, 2019 to use FreePBX bootstrap
 */
@@ -17,13 +17,35 @@ require_once('/etc/freepbx.conf');
 // Initialize a database connection
 global $db;
 
-// This pulls every extension in the systm. Including virtual mailboxes and is a recommended default
+// This pulls every standard phone/endpoint extension in the system, and is a recommended default. See below for customization.
 $sql = "SELECT `id`,`description` FROM `devices`;";
-// You can restrict the output with standard SQL syntax
-// This example only shows extensions prior to 200 and not virtual mailboxes
-// $sql = "SELECT `id`,`description` FROM `devices` WHERE `id` < 200 AND `tech` <> 'custom';";
-// This example will pull all extensions from 1000 to 1999
-// $sql = "SELECT `id`,`description` FROM `devices` WHERE `id` BETWEEN 1000 and 1999;";
+
+// The SQL command on Line 21 can be customized to pull extension numbers for ring groups, misc applications, queues, and possibly more.
+// Modified copies of this file may be saved alongside the original file, which will allow you to designate up to 5 separate Remote Phone Book tabs in the phone config.
+
+// To pull ring groups instead, uncomment the line below and comment out Line 21:
+// $sql = "SELECT `grpnum`,`description` FROM `ringgroups`;";
+// IMPORTANT - You must also change 'id' on Line 70 to 'grpnum'.
+
+// To pull Misc Applications, uncomment the line below and comment out Line 21:
+// $sql = "SELECT `ext`,`description` FROM `miscapps`;";
+// IMPORTANT - You must also change 'id' on Line 70 to 'ext'.
+
+// To pull Queues, uncomment the line below and comment out Line 21:
+// $sql = "SELECT `extension`,`descr` FROM `queues_config`;";
+// IMPORTANT - You must also change 'description' on Line 69 to 'descr' AND change 'id' on Line 70 to 'extension'
+
+// If you would like to include virtual extensions alongside your SIP extensions, uncomment the line below and comment out Line 21:
+// $sql = "SELECT `extension`,`name` FROM `users`;";
+// IMPORTANT - You must also change 'description' on Line 69 to 'name' AND change 'id' on Line 70 to 'extension'.
+
+// You can restrict the output of the command with standard SQL syntax, as shown below.
+
+// This example only shows extensions with a number below 200:
+// $sql = "SELECT `id`,`description` FROM `devices` WHERE `id` < 200;";
+
+// This example will pull all ring groups from 300 to 400 (remember to change Line 70 as mentioned above):
+// $sql = "SELECT `grpnum`,`description` FROM `ringgroups` WHERE `grpnum` BETWEEN 300 and 400;";
 
 // Execute the SQL statement
 $res = $db->prepare($sql);
@@ -37,7 +59,7 @@ if (DB::IsError($res)) {
     // output the XML header info
     echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
     // Output the XML root. This tag must be in the format XXXIPPhoneDirectory
-    // You may change the word Company below, but no other part of the root tag.
+    // You may change the word Company below, but no other part of the root tag. Make sure to change it on Line 74 too.
     echo "<CompanyIPPhoneDirectory  clearlight=\"true\">\n";
 
     // Loop through the results and output them correctly.
@@ -48,7 +70,7 @@ if (DB::IsError($res)) {
         echo "        <Telephone>" . $extension['id'] . "</Telephone>\n";
         echo "    </DirectoryEntry>\n";
     }
-    // Output the closing tag of the root. If you changed it above, make sure you change it here.
+    // Output the closing tag of the root. If you changed the tag above, make sure you change it here.
     echo "</CompanyIPPhoneDirectory>\n";
 }
 


### PR DESCRIPTION
I added some sample SQL commands that allow for pulling ring groups, misc apps, and queues instead of phone extensions. Additionally, I updated some wording to match the current databases used in FPBX 17, since the default SQL command no longer pulls virtual extensions.